### PR TITLE
Publish well-known identity resources

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
+          # Identity and security resources live under /.well-known. The action
+          # excludes dot-prefixed paths unless this input is enabled explicitly.
+          include-hidden-files: true
           path: ./dist
 
   deploy:
@@ -76,3 +79,34 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  verify-deployment:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Verify published identity resources
+        shell: bash
+        run: |
+          for attempt in {1..12}; do
+            if curl --fail --silent --show-error \
+              --header 'Cache-Control: no-cache' \
+              'https://yusuke-hayashi.com/.well-known/verify-identity.mjs' \
+              --output verify-identity.mjs \
+              && node verify-identity.mjs --local-only --report identity-health.json; then
+              exit 0
+            fi
+
+            if [[ "$attempt" -lt 12 ]]; then
+              sleep 10
+            fi
+          done
+
+          exit 1
+      - name: Upload deployment health report
+        if: always() && hashFiles('identity-health.json') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: identity-health-${{ github.sha }}
+          path: identity-health.json
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ pnpm security:audit
 GitHub Actions(`.github/workflows/pages.yml`)で lint → audit → `astro build` → GitHub Pages(`dist/`)。
 `build.format: "file"` により `/keys` などの拡張子なし URL を 301 なしで維持しています。
 sitemap は `src/pages/sitemap.xml.ts` の静的エンドポイントで、`robots.txt` の記載と同じ `/sitemap.xml` 名で生成します。
+Pages 用artifactでは `include-hidden-files: true` を必須とし、`/.well-known` を公開対象から落とさない。
+デプロイ後は公開済み検証 CLI を取得して site-owned artifact を再検証し、公開経路まで含めてCIで確認する。
 
 `main` の build では `dist/` を再現可能な `site-dist.tar.gz` にまとめ、GitHub Artifact
 Attestation で commit・workflow・成果物 digest の provenance を発行する。ダウンロードした成果物は


### PR DESCRIPTION
## Summary
- include dot-prefixed `/.well-known` resources in the GitHub Pages artifact
- verify the live site-owned identity surface after deployment with propagation retries
- record the deployment invariant in the repository README

## Verification
- `pnpm lint`
- `pnpm build`
- `node dist/.well-known/verify-identity.mjs --artifact-dir dist --local-only` (11/11 healthy)