### PR TITLE
Make profile artifacts reproducible

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,10 +44,23 @@ jobs:
         run: pnpm build
       - name: Verify identity artifacts
         run: node dist/.well-known/verify-identity.mjs --artifact-dir dist --local-only --report identity-health.json
-      - name: Package reproducible site artifact
-        if: github.event_name == 'push'
+      - name: Verify and package reproducible site artifact
         shell: bash
-        run: tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -cf - -C dist . | gzip -n > site-dist.tar.gz
+        run: |
+          create_archive() {
+            tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -cf - -C dist . \
+              | gzip -n > "$1"
+          }
+
+          create_archive "$RUNNER_TEMP/site-dist-first.tar.gz"
+          pnpm build
+          create_archive site-dist.tar.gz
+
+          first_digest="$(sha256sum "$RUNNER_TEMP/site-dist-first.tar.gz" | cut -d ' ' -f 1)"
+          second_digest="$(sha256sum site-dist.tar.gz | cut -d ' ' -f 1)"
+          echo "first build:  $first_digest"
+          echo "second build: $second_digest"
+          test "$first_digest" = "$second_digest"
       - name: Attest site artifact provenance
         if: github.event_name == 'push'
         uses: actions/attest@v4

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ sitemap は `src/pages/sitemap.xml.ts` の静的エンドポイントで、`robo
 Pages 用artifactでは `include-hidden-files: true` を必須とし、`/.well-known` を公開対象から落とさない。
 デプロイ後は公開済み検証 CLI を取得して site-owned artifact を再検証し、公開経路まで含めてCIで確認する。
 
-`main` の build では `dist/` を再現可能な `site-dist.tar.gz` にまとめ、GitHub Artifact
+CIでは同じcommitを2回buildし、固定metadataで作った `site-dist.tar.gz` のSHA-256一致を必須にする。
+`main` の build では検証済みのarchiveに対してGitHub Artifact
 Attestation で commit・workflow・成果物 digest の provenance を発行する。ダウンロードした成果物は
 `gh attestation verify site-dist.tar.gz -R yhay81/profile` で検証できる。
 

--- a/src/components/Icon.astro
+++ b/src/components/Icon.astro
@@ -7,11 +7,10 @@ interface Props {
 }
 
 const { name, title } = Astro.props;
-const titleId = `icon-${name}-${crypto.randomUUID().slice(0, 8)}`;
 ---
 
 <svg
-  aria-labelledby={titleId}
+  aria-label={title}
   fill="none"
   role="img"
   stroke="currentColor"
@@ -21,7 +20,7 @@ const titleId = `icon-${name}-${crypto.randomUUID().slice(0, 8)}`;
   viewBox="0 0 24 24"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <title id={titleId}>{title}</title>
+  <title>{title}</title>
   {
     name === "github" && (
       <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />


### PR DESCRIPTION
## Summary
- remove build-time random SVG title identifiers
- build and archive the site twice in CI and require matching SHA-256 digests
- document the reproducibility guarantee

## Verification
- `pnpm lint`
- `pnpm security:audit`
- two local builds produced identical per-file digests
- local identity verification: 11/11 healthy